### PR TITLE
drivers: input: gpio_keys: do not suspend buttons

### DIFF
--- a/drivers/input/input_gpio_keys.c
+++ b/drivers/input/input_gpio_keys.c
@@ -205,6 +205,12 @@ static int gpio_keys_init(const struct device *dev)
 		return ret;
 	}
 
+	ret = pm_device_runtime_get(dev);
+	if (ret < 0) {
+		LOG_ERR("Failed to resume device");
+		return ret;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
RT-1000-387: Do not suspend gpio which is in use by buttons