### PR TITLE
mgmt: mcumgr: transport: smp: Fix smp_transport_clients list init.

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp.c
@@ -32,7 +32,7 @@ K_THREAD_STACK_DEFINE(smp_work_queue_stack, CONFIG_MCUMGR_TRANSPORT_WORKQUEUE_ST
 static struct k_work_q smp_work_queue;
 
 #ifdef CONFIG_SMP_CLIENT
-static sys_slist_t smp_transport_clients;
+static sys_slist_t smp_transport_clients = SYS_SLIST_STATIC_INIT(&smp_transport_clients);
 #endif
 
 static const struct k_work_queue_config smp_work_queue_config = {
@@ -266,10 +266,6 @@ void smp_rx_clear(struct smp_transport *zst)
 
 static int smp_init(void)
 {
-#ifdef CONFIG_SMP_CLIENT
-	sys_slist_init(&smp_transport_clients);
-#endif
-
 	k_work_queue_init(&smp_work_queue);
 
 	k_work_queue_start(&smp_work_queue, smp_work_queue_stack,


### PR DESCRIPTION
Make sure smp_transport_clients list is only initialized once and before any transports will try to register and add entries to this list.

The smp_init() routine was called after smp_init_uart(), causing the list to be emptied again after registration of the uart client transport.