### PR TITLE
RT-1000-458: set thread names for lis2dw12 and lps22hh sensor threads

### DIFF
--- a/drivers/sensor/st/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/st/lis2dw12/lis2dw12_trigger.c
@@ -464,6 +464,7 @@ int lis2dw12_init_interrupt(const struct device *dev)
 		       lis2dw12_thread, lis2dw12,
 		       NULL, NULL, K_PRIO_COOP(CONFIG_LIS2DW12_THREAD_PRIORITY),
 		       0, K_NO_WAIT);
+	k_thread_name_set(&lis2dw12->thread, "lis2dw12");
 #elif defined(CONFIG_LIS2DW12_TRIGGER_GLOBAL_THREAD)
 	lis2dw12->work.handler = lis2dw12_work_cb;
 #endif /* CONFIG_LIS2DW12_TRIGGER_OWN_THREAD */

--- a/drivers/sensor/st/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/st/lps22hh/lps22hh_trigger.c
@@ -195,6 +195,7 @@ int lps22hh_init_interrupt(const struct device *dev)
 		       lps22hh_thread, lps22hh,
 		       NULL, NULL, K_PRIO_COOP(CONFIG_LPS22HH_THREAD_PRIORITY),
 		       0, K_NO_WAIT);
+	k_thread_name_set(&lps22hh->thread, "lps22hh");
 #elif defined(CONFIG_LPS22HH_TRIGGER_GLOBAL_THREAD)
 	lps22hh->work.handler = lps22hh_work_cb;
 #endif /* CONFIG_LPS22HH_TRIGGER_OWN_THREAD */


### PR DESCRIPTION
 - Set thread names for lis2dw12 and lps22hh sensor threads. This allows to distinguish the threads in the output of the "kernel thread list" shell command.