### PR TITLE
RT-1000-443: Add configurable delay before SPI NOR Flash initialization

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -89,4 +89,10 @@ config SPI_NOR_ACTIVE_DWELL_MS
 	  call, eliminating the active->idle->active transition sequence if another
 	  transaction occurs before the dwell period expires.
 
+config SPI_NOR_INIT_DELAY
+	int "Delay in milliseconds before SPI NOR Flash initialization"
+	default 0
+	help
+	  The delay is required on some boards for the Flash to get power
+
 endif # SPI_NOR

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -1512,6 +1512,8 @@ static int spi_nor_pm_control(const struct device *dev, enum pm_device_action ac
  */
 static int spi_nor_init(const struct device *dev)
 {
+	k_sleep(K_MSEC(CONFIG_SPI_NOR_INIT_DELAY));
+
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		struct spi_nor_data *const driver_data = dev->data;
 


### PR DESCRIPTION
RT-1000-443: Add configurable delay before SPI NOR Flash initialization