### PR TITLE
subsys: mgmt: mcumgr: grp: img_mgmt: Find all images by hash not only the first one

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/include/mgmt/mcumgr/grp/img_mgmt/img_mgmt_priv.h
@@ -213,6 +213,7 @@ void img_mgmt_release_lock(void);
 int img_mgmt_erased_val(int slot, uint8_t *erased_val);
 
 int img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver);
+int img_mgmt_find_by_hash_next(uint8_t *find, struct image_version *ver, int slot);
 int img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash);
 int img_mgmt_state_read(struct smp_streamer *ctxt);
 int img_mgmt_state_write(struct smp_streamer *njb);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -327,6 +327,34 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
 }
 
 /*
+ * Finds image given hash of the image.
+ * Starts searching from the specified slot.
+ * Returns the slot number image is in, or -1 if not found.
+ */
+int img_mgmt_find_by_hash_next(uint8_t *find, struct image_version *ver, int slot)
+{
+	int i;
+	bool skip = (slot >= 0);
+	uint8_t hash[IMAGE_SHA_LEN];
+
+	for (i = 0; i < 2 * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
+		if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
+			continue;
+		}
+		if (!memcmp(hash, find, IMAGE_SHA_LEN)) {
+			if (skip) {
+				if (i == slot) {
+					skip = false;
+				}
+				continue;
+			}
+			return i;
+		}
+	}
+	return -1;
+}
+
+/*
  * Resets upload status to defaults (no upload in progress)
  */
 #ifdef CONFIG_MCUMGR_GRP_IMG_MUTEX

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -719,6 +719,12 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 					     IMG_MGMT_ERR_INVALID_HASH);
 			goto end;
 		}
+
+		rc = img_mgmt_set_next_boot_slot(slot, confirm);
+		if (rc != 0) {
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
+			goto end;
+		}
 	} else if (zhash.len != IMAGE_SHA_LEN) {
 		/* The img_mgmt_find_by_hash does exact length compare
 		 * so just fail here.
@@ -730,18 +736,29 @@ img_mgmt_state_write(struct smp_streamer *ctxt)
 
 		memcpy(hash, zhash.value, zhash.len);
 
-		slot = img_mgmt_find_by_hash(hash, NULL);
-		if (slot < 0) {
+		slot = -1;
+		rc = -1;
+		do {
+			slot = img_mgmt_find_by_hash_next(hash, NULL, slot);
+			if (slot < 0) {
+				break;
+			}
+			rc = img_mgmt_set_next_boot_slot(slot, confirm);
+			if (rc) {
+			}
+		} while (rc);
+
+		if (rc > 0) {
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
+			goto end;
+		} else if (slot < 0) {
 			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE,
 					     IMG_MGMT_ERR_HASH_NOT_FOUND);
 			goto end;
+		} else if (rc < 0) {
+			ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
+			goto end;
 		}
-	}
-
-	rc = img_mgmt_set_next_boot_slot(slot, confirm);
-	if (rc != 0) {
-		ok = smp_add_cmd_err(zse, MGMT_GROUP_ID_IMAGE, rc);
-		goto end;
 	}
 
 	/* Send the current image state in the response. */


### PR DESCRIPTION
RT-1000-429: Avoid FOTA error if the new and old image are identical