### PR TITLE
logging: log_backend_fs: allow to configure stack size of the work queue

### DIFF
--- a/subsys/logging/backends/Kconfig.fs
+++ b/subsys/logging/backends/Kconfig.fs
@@ -66,4 +66,10 @@ config LOG_BACKEND_FS_FILES_LIMIT
 	  Limit of number of files with logs. It is also limited by
 	  size of file system partition.
 
+config LOG_BACKEND_FS_STACK_SIZE
+	int "Backend work queue stack size"
+	default 3072
+	help
+	  Set stack size for the work queue writing to FS
+
 endif # LOG_BACKEND_FS

--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -28,10 +28,7 @@ struct logfs_msg {
 #define MSG_SIZE 4
 
 K_MSGQ_DEFINE(log_msgq, sizeof(struct logfs_msg), MSG_SIZE, 1);
-
-#define LOG_BACKEND_FS_STACK_SIZE	2048
-
-K_THREAD_STACK_DEFINE(logfs_queue_stack_area, LOG_BACKEND_FS_STACK_SIZE);
+K_THREAD_STACK_DEFINE(logfs_queue_stack_area, CONFIG_LOG_BACKEND_FS_STACK_SIZE);
 static struct k_work_q logfs_queue_work_q;
 static struct k_work logfs_msg_work;
 


### PR DESCRIPTION
RT-1000-570:
 - Add configuration parameter for setting the stack size of the work queue writing to FS.