### PR TITLE
logging: multidomain logs: do not reset on error

### DIFF
--- a/subsys/logging/backends/log_multidomain_backend.c
+++ b/subsys/logging/backends/log_multidomain_backend.c
@@ -74,7 +74,7 @@ static void process(const struct log_backend *const backend,
 
 	err = backend_remote->transport_api->send(backend_remote, out_msg, msg_len + msg_offset);
 	if (err < 0) {
-		__ASSERT(false, "Unexpected error: %d\n", err);
+		/* __ASSERT(false, "Unexpected error: %d\n", err); */
 		return;
 	}
 }


### PR DESCRIPTION
RT-1000-589:
- Do not stop system if multidomain log communication is failed