### PR TITLE
logging: log_backend_fs: increase priority of the consumer thread

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -25,7 +25,7 @@
 #define FILE_NUMERAL_LEN 4
 #endif
 
-#define THREAD_PRIORITY (K_LOWEST_APPLICATION_THREAD_PRIO - 1)
+#define THREAD_PRIORITY (K_LOWEST_APPLICATION_THREAD_PRIO - 2)
 
 struct logfs_msg {
 	uint8_t buf[MAX_FLASH_WRITE_SIZE];
@@ -312,6 +312,7 @@ static int logfs_producer(uint8_t *data, size_t length, void *ctx)
 	ret = k_msgq_put(&log_msgq, &msg, K_NO_WAIT);
 	if (ret) {
 		/* msgq is full */
+		k_yield();
 		return 0;
 	}
 


### PR DESCRIPTION
Fixes RT-1000-601.