### PR TITLE
logging: log_backend_fs: fix time based log autorotate

### DIFF
--- a/subsys/logging/backends/log_backend_fs.c
+++ b/subsys/logging/backends/log_backend_fs.c
@@ -452,8 +452,6 @@ static int allocate_new_file(struct fs_file_t *file)
 		backend_state = BACKEND_FS_OK;
 		last_rotation_time = uptime;
 		current_boot_start_uptime = uptime;
-		/* rotate logs */
-		del_oldest_log();
 		goto out;
 #else
 		/* Search for the last used log number. */


### PR DESCRIPTION
RT-1000-631:
 - Don't try to delete oldest files during initialization. This can lead to deletion of the currently active file if the logs directory was empty before initialization.