### PR TITLE
RT-1000-688: BQ274xx: allow use unfiltered soc

### DIFF
--- a/drivers/sensor/ti/bq274xx/bq274xx.c
+++ b/drivers/sensor/ti/bq274xx/bq274xx.c
@@ -621,7 +621,12 @@ static int bq274xx_sample_fetch(const struct device *dev, enum sensor_channel ch
 	}
 
 	if (chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_GAUGE_STATE_OF_CHARGE) {
-		ret = bq274xx_cmd_reg_read(dev, BQ274XX_CMD_SOC,
+		const struct bq274xx_config *config = dev->config;
+		const unsigned char cmd = config->report_unfiltered_soc
+					? BQ274XX_CMD_SOC_UNFL
+					: BQ274XX_CMD_SOC;
+
+		ret = bq274xx_cmd_reg_read(dev, cmd,
 					   &data->state_of_charge);
 		if (ret < 0) {
 			LOG_ERR("Failed to read state of charge");
@@ -874,6 +879,7 @@ static const struct sensor_driver_api bq274xx_battery_driver_api = {
 		.terminate_voltage = DT_INST_PROP(index, terminate_voltage),	\
 		.chemistry_id = DT_INST_PROP_OR(index, chemistry_id, 0),			\
 		.lazy_loading = DT_INST_PROP(index, zephyr_lazy_load),		\
+		.report_unfiltered_soc = DT_INST_PROP(index, report_unfiltered_soc),		\
 	};									\
 										\
 	PM_BQ274XX_DT_INST_DEFINE(index, bq274xx_pm_action);			\

--- a/drivers/sensor/ti/bq274xx/bq274xx.h
+++ b/drivers/sensor/ti/bq274xx/bq274xx.h
@@ -127,6 +127,7 @@ struct bq274xx_config {
 #endif
 	uint16_t chemistry_id;
 	bool lazy_loading;
+	bool report_unfiltered_soc;
 };
 
 int bq274xx_trigger_mode_init(const struct device *dev);

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -56,3 +56,10 @@ properties:
     description: |
       Configuring the sensor can take a long time, using lazy loading we can delay
       until the first sample request and keep the boot time as short as possible.
+
+  report_unfiltered_soc:
+    type: boolean
+    description: |
+      Report StateOfChargeUnfiltered() instead of StateOfCharge().
+      This is workaround for the case where fully charged(FC) is not
+      detected, so StateOfCharge() is kept at 99% despite charge stopped.


### PR DESCRIPTION
As a workaround, for BQ274xx does not detect fully charged(FC) event, allow driver to report unfiltered SOC value.
This is just workaround, the proper method is to adjust BQ274xx setup to detect SOC.