### PR TITLE
drivers: sensor: npm1300_charger: Make the battery thermistor optional

### DIFF
--- a/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
+++ b/drivers/sensor/nordic/npm1300_charger/npm1300_charger.c
@@ -456,6 +456,7 @@ int npm1300_charger_init(const struct device *dev)
 {
 	const struct npm1300_charger_config *const config = dev->config;
 	uint16_t idx;
+	uint8_t reg = 0;
 	int ret;
 
 	if (!device_is_ready(config->mfd)) {
@@ -469,7 +470,12 @@ int npm1300_charger_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = set_ntc_thresholds(config);
+	if ((config->thermistor_ohms != 0) && (config->thermistor_beta != 0)) {
+		ret = set_ntc_thresholds(config);
+	} else {
+		reg = 2U;
+		ret = mfd_npm1300_reg_write(config->mfd, CHGR_BASE, CHGR_OFFSET_DIS_SET, reg);
+	}
 	if (ret != 0) {
 		return ret;
 	}
@@ -590,7 +596,8 @@ int npm1300_charger_init(const struct device *dev)
 
 	/* Disable automatic recharging if configured */
 	if (config->disable_recharge) {
-		ret = mfd_npm1300_reg_write(config->mfd, CHGR_BASE, CHGR_OFFSET_DIS_SET, 1U);
+		reg |= 1U;
+		ret = mfd_npm1300_reg_write(config->mfd, CHGR_BASE, CHGR_OFFSET_DIS_SET, reg);
 		if (ret != 0) {
 			return ret;
 		}

--- a/dts/bindings/sensor/nordic,npm1300-charger.yaml
+++ b/dts/bindings/sensor/nordic,npm1300-charger.yaml
@@ -50,8 +50,9 @@ properties:
 
   thermistor-ohms:
     type: int
-    required: true
+    default: 0
     enum:
+      - 0
       - 10000
       - 47000
       - 100000
@@ -59,7 +60,7 @@ properties:
 
   thermistor-beta:
     type: int
-    required: true
+    default: 0
     description: Beta value of selected thermistor.
 
   thermistor-cold-millidegrees:


### PR DESCRIPTION
RM7440: Make the battery thermistor optional:
- Set the  DISABLENTC bit in BCHGDISABLESET register if thermistor-ohms or thermistor-beta is set to 0 or omitted