### PR TITLE
CB24FW-709: add option for assigning all unused memory for system heap

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -749,6 +749,12 @@ config HEAP_MEM_POOL_IGNORE_MIN
 	  when optimizing memory usage and a more precise minimum heap size
 	  is known for a given application.
 
+config HEAP_MEM_TAKE_REMAINDER
+	bool "Use all remaining RAM for heap memory pool"
+	help
+	  This option can be set to use all remaining memory for heap memory
+	  pool rather than specifying constant size.
+
 endif # KERNEL_MEM_POOL
 
 endmenu

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -22,6 +22,13 @@ void k_heap_init(struct k_heap *heap, void *mem, size_t bytes)
 
 static int statics_init(void)
 {
+#if defined(CONFIG_HEAP_MEM_TAKE_REMAINDER)
+	extern struct k_heap _system_heap;
+
+	k_heap_init(&_system_heap, (void *)&_image_ram_end,
+		    (uint32_t)&__kernel_ram_end - (uint32_t)&_image_ram_end);
+#endif
+
 	STRUCT_SECTION_FOREACH(k_heap, heap) {
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
 		/* Some heaps may not present at boot, so we need to wait for

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -57,9 +57,13 @@ void k_free(void *ptr)
 	}
 }
 
-#if (K_HEAP_MEM_POOL_SIZE > 0)
+#if (K_HEAP_MEM_POOL_SIZE > 0) || defined(CONFIG_HEAP_MEM_TAKE_REMAINDER)
 
+#if defined(CONFIG_HEAP_MEM_TAKE_REMAINDER)
+struct k_heap _system_heap;
+#else
 K_HEAP_DEFINE(_system_heap, K_HEAP_MEM_POOL_SIZE);
+#endif
 #define _SYSTEM_HEAP (&_system_heap)
 
 void *k_aligned_alloc(size_t align, size_t size)


### PR DESCRIPTION
Fixes CB24FW-709: Allocate remaining RAM to heap